### PR TITLE
Use though2 and other clean up for newer Node versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,14 +4,14 @@ var os = require('os')
 
 module.exports = BinarySplit
 
-function BinarySplit(matcher) {
+function BinarySplit (matcher) {
   if (!(this instanceof BinarySplit)) return new BinarySplit(matcher)
-  var matcher = bops.from(matcher || os.EOL)
+  matcher = bops.from(matcher || os.EOL)
   var buffered
   var bufcount = 0
   return through(write, end)
 
-  function write(buf, enc, done) {
+  function write (buf, enc, done) {
     bufcount++
     var offset = 0
 
@@ -47,14 +47,13 @@ function BinarySplit(matcher) {
     done()
   }
 
-  function end(done) {
+  function end (done) {
     if (buffered) this.push(buffered)
     this.push(null)
     done()
   }
 
-  function firstMatch(buf, offset) {
-    var i = offset
+  function firstMatch (buf, offset) {
     if (offset >= buf.length) return false
     for (var i = offset; i < buf.length; i++) {
       if (buf[i] === matcher[0]) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var bops = require('bops')
-var through = require('through')
+var through = require('through2')
 var os = require('os')
 
 module.exports = BinarySplit
@@ -10,16 +10,16 @@ function BinarySplit(matcher) {
   var buffered
   var bufcount = 0
   return through(write, end)
-  
-  function write(buf) { 
+
+  function write(buf, enc, done) {
     bufcount++
     var offset = 0
-        
+
     if (buffered) {
       buf = bops.join([buffered, buf])
       buffered = undefined
     }
-    
+
     while (buf) {
       var idx = firstMatch(buf, offset)
       if (idx) {
@@ -29,7 +29,7 @@ function BinarySplit(matcher) {
           buf = undefined
           offset = idx
         } else {
-          this.queue(line)
+          this.push(line)
           offset = idx + matcher.length
         }
       } else if (idx === 0) {
@@ -43,13 +43,16 @@ function BinarySplit(matcher) {
         buf = undefined
       }
     }
+
+    done()
   }
-  
-  function end() {
-    if (buffered) this.queue(buffered)
-    this.queue(null)
+
+  function end(done) {
+    if (buffered) this.push(buffered)
+    this.push(null)
+    done()
   }
-  
+
   function firstMatch(buf, offset) {
     var i = offset
     if (offset >= buf.length) return false

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "url": "https://github.com/maxogden/binary-split/issues"
   },
   "dependencies": {
+    "bops": "0.1.1",
     "through": "~2.3.4",
-    "bops": "0.1.1"
+    "through2": "^2.0.0"
   },
   "devDependencies": {
     "tape": "~4.2.2"

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "through": "~2.3.4",
-    "bops": "0.0.6"
+    "bops": "0.1.1"
   },
   "devDependencies": {
-    "tape": "~1.1.0"
+    "tape": "~4.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "a fast newline (or any delimiter) splitter stream - like require('split') but faster",
   "main": "index.js",
   "scripts": {
-    "test": "node test.js"
+    "test": "standard && node test.js"
   },
   "repository": {
     "type": "git",
@@ -17,10 +17,10 @@
   },
   "dependencies": {
     "bops": "0.1.1",
-    "through": "~2.3.4",
     "through2": "^2.0.0"
   },
   "devDependencies": {
+    "standard": "^5.4.1",
     "tape": "~4.2.2"
   }
 }

--- a/test.js
+++ b/test.js
@@ -2,35 +2,35 @@ var test = require('tape')
 var fs = require('fs')
 var split = require('./')
 
-function splitTest(matcher, cb) {
+function splitTest (matcher, cb) {
   if (!cb) {
     cb = matcher
     matcher = undefined
   }
   var splitter = split(matcher)
   var items = []
-  splitter.on('data', function(item) {
+  splitter.on('data', function (item) {
     items.push(item)
   })
-  splitter.on('error', function(e) {
+  splitter.on('error', function (e) {
     cb(e)
   })
-  splitter.on('end', function() {
+  splitter.on('end', function () {
     cb(false, items)
   })
   return splitter
 }
 
-test('ldjson file', function(t) {
-  fs.createReadStream('test.json').pipe(splitTest(function(err, items) {
+test('ldjson file', function (t) {
+  fs.createReadStream('test.json').pipe(splitTest(function (err, items) {
     if (err) throw err
     t.equals(items.length, 3)
     t.end()
   }))
 })
 
-test('custom matcher', function(t) {
-  var splitStream = splitTest(' ', function(err, items) {
+test('custom matcher', function (t) {
+  var splitStream = splitTest(' ', function (err, items) {
     if (err) throw err
     t.equals(items.length, 5)
     t.equals(items.join(' '), 'hello yes this is dog')
@@ -40,8 +40,8 @@ test('custom matcher', function(t) {
   splitStream.end()
 })
 
-test('long matcher', function(t) {
-  var splitStream = splitTest('this', function(err, items) {
+test('long matcher', function (t) {
+  var splitStream = splitTest('this', function (err, items) {
     if (err) throw err
     t.equals(items.length, 2)
     t.equals(items[0].toString(), 'hello yes ')
@@ -52,8 +52,8 @@ test('long matcher', function(t) {
   splitStream.end()
 })
 
-test('matcher at index 0 check', function(t) {
-  var splitStream = splitTest(function(err, items) {
+test('matcher at index 0 check', function (t) {
+  var splitStream = splitTest(function (err, items) {
     if (err) throw err
 
     t.equals(items.length, 2)


### PR DESCRIPTION
@maxogden given that this module is awesome and very useful but wasn't updated for almost 2 years, I thought I'd give it a minor update. :)

- switched to though2 to ensure everything works on newer Node versions and has benefits of streams2
- added standard since I noticed that you use it for your modules now
- made sure tests pass on Node 5, 0.12 and 0.10

Let me know if there's anything else to do here before you can merge and push a new version to NPM.