### PR TITLE
use global offset for buffered chunks

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,25 +22,13 @@ function BinarySplit (matcher) {
 
     while (buf) {
       var idx = firstMatch(buf, offset)
-      if (idx) {
-        if (idx === buf.length) {
-          buffered = buf
-          buf = undefined
-          offset = idx
-        } else {
-          this.push(bops.subarray(buf, 0, idx))
-          buf = bops.subarray(buf, idx)
-          offset = 0
-        }
-      } else if (idx === 0) {
-        buf = bops.subarray(buf, offset + matcher.length)
+      if (idx !== -1 && idx < buf.length) {
+        this.push(bops.subarray(buf, 0, idx))
+        buf = bops.subarray(buf, idx + matcher.length)
+        offset = 0
       } else {
-        if (offset >= buf.length) {
-          buffered = undefined
-          offset = 0
-        } else {
-          buffered = buf
-        }
+        buffered = buf
+        offset = buf.length
         buf = undefined
       }
     }
@@ -55,7 +43,7 @@ function BinarySplit (matcher) {
   }
 
   function firstMatch (buf, offset) {
-    if (offset >= buf.length) return false
+    if (offset >= buf.length) return -1
     for (var i = offset; i < buf.length; i++) {
       if (buf[i] === matcher[0]) {
         if (matcher.length > 1) {

--- a/index.js
+++ b/index.js
@@ -9,11 +9,11 @@ function BinarySplit (matcher) {
   matcher = bops.from(matcher || os.EOL)
   var buffered
   var bufcount = 0
+  var offset = 0
   return through(write, end)
 
   function write (buf, enc, done) {
     bufcount++
-    var offset = 0
 
     if (buffered) {
       buf = bops.join([buffered, buf])
@@ -37,6 +37,7 @@ function BinarySplit (matcher) {
       } else {
         if (offset >= buf.length) {
           buffered = undefined
+          offset = 0
         } else {
           buffered = buf
         }

--- a/index.js
+++ b/index.js
@@ -23,14 +23,14 @@ function BinarySplit (matcher) {
     while (buf) {
       var idx = firstMatch(buf, offset)
       if (idx) {
-        var line = bops.subarray(buf, offset, idx)
         if (idx === buf.length) {
-          buffered = line
+          buffered = buf
           buf = undefined
           offset = idx
         } else {
-          this.push(line)
-          offset = idx + matcher.length
+          this.push(bops.subarray(buf, 0, idx))
+          buf = bops.subarray(buf, idx)
+          offset = 0
         }
       } else if (idx === 0) {
         buf = bops.subarray(buf, offset + matcher.length)

--- a/index.js
+++ b/index.js
@@ -9,27 +9,27 @@ function BinarySplit (matcher) {
   matcher = bops.from(matcher || os.EOL)
   var buffered
   var bufcount = 0
-  var offset = 0
   return through(write, end)
 
   function write (buf, enc, done) {
     bufcount++
-
+    var offset = 0
+    var lastMatch = 0
     if (buffered) {
       buf = bops.join([buffered, buf])
+      offset = buffered.length
       buffered = undefined
     }
 
-    while (buf) {
+    while (true) {
       var idx = firstMatch(buf, offset)
       if (idx !== -1 && idx < buf.length) {
-        this.push(bops.subarray(buf, 0, idx))
-        buf = bops.subarray(buf, idx + matcher.length)
-        offset = 0
+        this.push(bops.subarray(buf, lastMatch, idx))
+        offset = idx + matcher.length
+        lastMatch = offset
       } else {
-        buffered = buf
-        offset = buf.length
-        buf = undefined
+        buffered = bops.subarray(buf, lastMatch)
+        break
       }
     }
 

--- a/test.js
+++ b/test.js
@@ -76,3 +76,14 @@ test('chunked input', function (t) {
     t.end()
   }))
 })
+
+test('chunked input with long matcher', function (t) {
+  fs.createReadStream('test.json')
+  .pipe(split('\n'))
+  .pipe(splitTest('hello', function (err, items) {
+    if (err) throw err
+    t.equals(items.length, 2)
+    t.equals(items[0].toString(), '{"')
+    t.end()
+  }))
+})

--- a/test.js
+++ b/test.js
@@ -65,3 +65,14 @@ test('matcher at index 0 check', function (t) {
   splitStream.write(new Buffer('\nhello\nmax'))
   splitStream.end()
 })
+
+test('chunked input', function (t) {
+  fs.createReadStream('test.json')
+  .pipe(split('\n'))
+  .pipe(split('i'))
+  .pipe(splitTest(':', function (err, items) {
+    if (err) throw err
+    t.equals(items.length, 4)
+    t.end()
+  }))
+})


### PR DESCRIPTION
For split matchers that occur rarely in a stream with many chunks, resetting the search offset inside the handler makes for very bad performance (e.g. for a matcher that doesn't occur at all, the runtime is `O(N²)` where N is the total number of chunks in the stream). Moving the offset outside of the stream-chunk-handler restores linear runtime.