### PR TITLE
Simplify match function

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,30 +37,18 @@ function BinarySplit (matcher) {
 
   function end (done) {
     if (buffered) this.push(buffered)
-    this.push(null)
     done()
   }
 
   function firstMatch (buf, offset) {
     if (offset >= buf.length) return -1
-    for (var i = offset; i < buf.length; i++) {
-      if (buf[i] === matcher[0]) {
-        if (matcher.length > 1) {
-          var fullMatch = true
-          for (var j = i, k = 0; j < i + matcher.length; j++, k++) {
-            if (buf[j] !== matcher[k]) {
-              fullMatch = false
-              break
-            }
-          }
-          if (fullMatch) return j - matcher.length
-        } else {
-          break
-        }
-      }
-    }
 
-    var idx = i + matcher.length - 1
-    return idx
+    for (var i = offset, m = matcher.length; i < buf.length - m; i++) {
+      for (var j = 0; j < m; j++) {
+        if (buf[i + j] !== matcher[j]) break
+      }
+      if (j === m) return i
+    }
+    return buf.length
   }
 }


### PR DESCRIPTION
Simplifies the match function significantly, and indirectly closes #5. Performance is the same. 

@maxogden I know you were [concerned](https://github.com/maxogden/binary-split/issues/5#issuecomment-160756696) about maintaining this function in two places, but this should no longer be a concern.